### PR TITLE
2.2.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,21 +52,24 @@ jobs:
           fetch-depth: 0
 
       # -----------------------------------------------------------------------
-      # 3. Build the .NET application (version stamped from the tag)
+      # 3. Publish the .NET application (self-contained single-file, version stamped from the tag)
       # -----------------------------------------------------------------------
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.x'
 
-      - name: Build application
+      - name: Publish application
         shell: pwsh
         env:
           BUILD_VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           $v = $env:BUILD_VERSION
-          dotnet build qbPortWeaver.csproj `
+          dotnet publish qbPortWeaver.csproj `
             --configuration Release `
+            --runtime win-x64 `
+            --self-contained true `
+            /p:PublishSingleFile=true `
             /p:Version=$v `
             /p:FileVersion="$v.0" `
             /p:AssemblyVersion="$v.0"

--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -126,26 +126,55 @@ jobs:
           Write-Host "Package files updated for v$version"
 
       # -----------------------------------------------------------------------
-      # 6. Pack the Chocolatey package
+      # 6. Validate that all TEMPLATE_ placeholders were replaced
       # -----------------------------------------------------------------------
-      - name: Pack Chocolatey package
+      - name: Validate placeholder substitution
         shell: pwsh
         run: |
-          choco pack choco\qbPortWeaver.nuspec --output-directory .
-          $nupkg = Get-Item "*.nupkg" | Select-Object -First 1
-          Write-Host "Created: $($nupkg.Name)"
-          "NUPKG_PATH=$($nupkg.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        id: pack
+          $files = @(
+            'choco\qbPortWeaver.nuspec',
+            'choco\tools\chocolateyInstall.ps1',
+            'choco\tools\VERIFICATION.txt'
+          )
+          $found = $false
+          foreach ($file in $files) {
+            if (Select-String -Path $file -Pattern 'TEMPLATE_' -Quiet) {
+              Write-Error "Unreplaced TEMPLATE_ placeholder found in: $file"
+              $found = $true
+            }
+          }
+          if ($found) { exit 1 }
+          Write-Host "All placeholders replaced successfully."
 
       # -----------------------------------------------------------------------
-      # 7. Push to Chocolatey Community Repository
+      # 7. Pack the Chocolatey package
+      # -----------------------------------------------------------------------
+      - name: Pack Chocolatey package
+        id: pack
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.tag.outputs.VERSION }}
+        run: |
+          $version = $env:RELEASE_VERSION
+          choco pack choco\qbPortWeaver.nuspec --output-directory .
+          # Use the explicit versioned filename rather than a wildcard to avoid
+          # accidentally picking up a stale .nupkg from a previous run
+          $nupkg = Get-Item "qbportweaver.$version.nupkg"
+          Write-Host "Created: $($nupkg.Name)"
+          "NUPKG_PATH=$($nupkg.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # -----------------------------------------------------------------------
+      # 8. Push to Chocolatey Community Repository
       # -----------------------------------------------------------------------
       - name: Push to Chocolatey Community Repository
         shell: pwsh
         env:
+          RELEASE_VERSION: ${{ steps.tag.outputs.VERSION }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
         run: |
-          $nupkg = Get-Item "*.nupkg" | Select-Object -First 1
+          $version = $env:RELEASE_VERSION
+          # Use the explicit versioned filename — same reasoning as the pack step
+          $nupkg = Get-Item "qbportweaver.$version.nupkg"
           Write-Host "Pushing: $($nupkg.Name)"
           choco push $nupkg.FullName `
             --source https://push.chocolatey.org/ `

--- a/AppConstants.cs
+++ b/AppConstants.cs
@@ -6,7 +6,7 @@ namespace qbPortWeaver
     {
         // Application metadata
         public const string APP_NAME = "qbPortWeaver";
-        public const string APP_VERSION = "2.1.0";
+        public const string APP_VERSION = "2.2.0";
 
         // Timing
         public const int DEFAULT_UPDATE_INTERVAL_SECONDS = 180;

--- a/PortSyncService.cs
+++ b/PortSyncService.cs
@@ -110,7 +110,7 @@ namespace qbPortWeaver
             else
             {
                 if (!cfg.VpnProvider.Equals("ProtonVPN", StringComparison.OrdinalIgnoreCase))
-                    LogManager.Instance.LogMessage($"Unknown vpnProvider '{cfg.VpnProvider}', defaulting to ProtonVPN", "WARN");
+                    LogManager.Instance.LogMessage($"Unknown VPN provider '{cfg.VpnProvider}', defaulting to ProtonVPN", "WARN");
                 vpnManager = new ProtonVPNManager(AppConstants.GetProtonVPNLogFilePath());
             }
 
@@ -312,7 +312,7 @@ namespace qbPortWeaver
 
             if (config.Restart)
             {
-                LogManager.Instance.LogMessage("Restarting qBittorrent", "INFO");
+                LogManager.Instance.LogMessage("Attempting to restart qBittorrent", "INFO");
                 if (!await qBittorrentMgr.RestartAsync())
                 {
                     SetCompleted(status, false, "Failed to restart qBittorrent");
@@ -340,7 +340,7 @@ namespace qbPortWeaver
                     CreateNoWindow = true
                 };
                 Process.Start(psi)?.Dispose();
-                LogManager.Instance.LogMessage("Post-update command launched successfully", "INFO");
+                LogManager.Instance.LogMessage("Successfully launched post-update command", "INFO");
             }
             catch (Exception ex)
             {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qbPortWeaver 2.1.0
+# qbPortWeaver 2.2.0
 
 ## Overview
 
@@ -206,11 +206,14 @@ The modular architecture makes it easy to:
 
 ## Changelog
 
-### 2.1.0
+### 2.2.0
 - Removed legacy INI file migration code — v2.0.0 is the required baseline for upgrading
 - Internal code cleanup and consistency improvements across all modules
 - New **About** dialog (tray menu → About): shows current and latest GitHub release, update status, and contributor links
 - Update checker now also runs every 12 hours in the background, not only on startup
+- Distributed as a **self-contained single-file executable** — no .NET runtime installation required
+- Automated **CI/CD pipeline** via GitHub Actions: pushing a `v*` tag builds the app, compiles the NSIS installer, and publishes a GitHub Release automatically
+- Available on the **Chocolatey Community Repository**: `choco install qbportweaver`
 
 ### 2.0.0
 - **Tray status indicator**: the tray icon now shows a colored dot (green / orange / red) reflecting the last sync result, and the tooltip shows the current port and status without opening the log file

--- a/choco/qbPortWeaver.nuspec
+++ b/choco/qbPortWeaver.nuspec
@@ -53,7 +53,7 @@ On first launch, open **Settings** from the system tray icon to configure:
 - Sync interval
 - Startup options
     ]]></description>
-    <releaseNotes>https://github.com/martsg666/qbPortWeaver/releases/tag/TEMPLATE_VERSION</releaseNotes>
+    <releaseNotes>https://github.com/martsg666/qbPortWeaver/releases/tag/vTEMPLATE_VERSION</releaseNotes>
     <copyright>© 2026 @martsg666</copyright>
     <tags>qbittorrent vpn port-forwarding protonvpn pia private-internet-access system-tray torrent port-sync admin</tags>
     <licenseUrl>https://github.com/martsg666/qbPortWeaver#license</licenseUrl>

--- a/choco/qbPortWeaver.nuspec
+++ b/choco/qbPortWeaver.nuspec
@@ -58,10 +58,6 @@ On first launch, open **Settings** from the system tray icon to configure:
     <tags>qbittorrent vpn port-forwarding protonvpn pia private-internet-access system-tray torrent port-sync admin</tags>
     <licenseUrl>https://github.com/martsg666/qbPortWeaver#license</licenseUrl>
     <iconUrl>https://rawcdn.githack.com/martsg666/qbPortWeaver/master/qbPortWeaver.ico</iconUrl>
-    <dependencies>
-      <!-- .NET 10 Desktop Runtime — required unless the package is published as self-contained (which it is by default) -->
-      <!-- Remove this dependency block if using the self-contained single-file release -->
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/frmAbout.Designer.cs
+++ b/frmAbout.Designer.cs
@@ -97,7 +97,7 @@ namespace qbPortWeaver
             lblCurrentVersionValue.Name = "lblCurrentVersionValue";
             lblCurrentVersionValue.Size = new Size(200, 23);
             lblCurrentVersionValue.TabIndex = 1;
-            lblCurrentVersionValue.Text = "2.1.0";
+            lblCurrentVersionValue.Text = "";
             lblCurrentVersionValue.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // lblLatestVersionLabel

--- a/frmAbout.cs
+++ b/frmAbout.cs
@@ -10,16 +10,19 @@ namespace qbPortWeaver
         public frmAbout()
         {
             InitializeComponent();
-            lblAppVersion.Text = $"Version {AppConstants.APP_VERSION}";
-            lnkGitHub.Text     = $"{AppConstants.GITHUB_REPO_OWNER}/{AppConstants.APP_NAME}";
-            Text               = $"{AppConstants.APP_NAME} | About";
+            lblAppVersion.Text         = $"Version {AppConstants.APP_VERSION}";
+            lblCurrentVersionValue.Text = AppConstants.APP_VERSION;
+            lnkGitHub.Text             = $"{AppConstants.GITHUB_REPO_OWNER}/{AppConstants.APP_NAME}";
+            Text                       = $"{AppConstants.APP_NAME} | About";
         }
 
         // Kick off the GitHub data fetch as fire-and-forget; the IsDisposed guard in the async method handles early close
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            _ = LoadGitHubDataAsync();
+            _ = LoadGitHubDataAsync().ContinueWith(
+                t => LogManager.Instance.LogDebug($"frmAbout.LoadGitHubDataAsync: {t.Exception?.GetBaseException().Message}"),
+                TaskContinuationOptions.OnlyOnFaulted);
         }
 
         // Fetches the latest release info and contributor list in parallel, then populates all UI fields

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -177,9 +177,11 @@ namespace qbPortWeaver
         {
             try
             {
+                LogManager.Instance.LogMessage("Checking for application updates", "INFO");
                 var update = await UpdateChecker.CheckForUpdateAsync();
                 if (update.HasValue)
                 {
+                    LogManager.Instance.LogMessage($"New application version available: {update.Value.Version}", "INFO");
                     var result = MessageBox.Show(
                         $"A new version of {AppConstants.APP_NAME} is available: {update.Value.Version}\n\nWould you like to open the download page?",
                         $"{AppConstants.APP_NAME} - Update Available",
@@ -189,10 +191,14 @@ namespace qbPortWeaver
                     if (result == DialogResult.Yes)
                         Process.Start(new ProcessStartInfo(update.Value.Url) { UseShellExecute = true })?.Dispose();
                 }
+                else
+                {
+                    LogManager.Instance.LogMessage("Application is up to date", "INFO");
+                }
             }
             catch (Exception ex)
             {
-                LogManager.Instance.LogDebug($"frmMain.PerformUpdateCheckAsync: Update check failed: {ex.Message}");
+                LogManager.Instance.LogDebug($"frmMain.PerformUpdateCheckAsync: {ex.Message}");
             }
         }
 
@@ -219,7 +225,7 @@ namespace qbPortWeaver
                     {
                         _manualSyncTriggered = false;
                         updateInterval = AppConstants.MANUAL_SYNC_WAIT_SECONDS;
-                        LogManager.Instance.LogMessage($"Manual sync completed, waiting {AppConstants.MANUAL_SYNC_WAIT_SECONDS} seconds before resuming normal interval", "INFO");
+                        LogManager.Instance.LogMessage("Manual sync complete", "INFO");
                     }
 
                     if (await ShutdownRequestedDuringDelayAsync(updateInterval))

--- a/installer/qbPortWeaverSetup.nsi
+++ b/installer/qbPortWeaverSetup.nsi
@@ -5,7 +5,7 @@
 ; PRODUCT_VERSION can be overridden at compile time with:
 ;   makensis /DPRODUCT_VERSION=x.y.z qbPortWeaverSetup.nsi
 !ifndef PRODUCT_VERSION
-  !define PRODUCT_VERSION "2.1.0"
+  !define PRODUCT_VERSION "2.2.0"
 !endif
 !define PRODUCT_PUBLISHER "@martsg666"
 !define PRODUCT_WEB_SITE "https://github.com/martsg666/qbPortWeaver"
@@ -37,6 +37,9 @@ Page custom PostInstallNotice
 ; Language files
 !insertmacro MUI_LANGUAGE "English"
 ; MUI end ------
+
+; Require administrator rights — needed to install to $PROGRAMFILES64
+RequestExecutionLevel admin
 
 Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
 OutFile "${PRODUCT_NAME}_${PRODUCT_VERSION}_Setup.exe"
@@ -86,7 +89,7 @@ Section "MainSection" SEC01
   SetOutPath "$INSTDIR"
   SetOverwrite on
   SetRebootFlag false
-  File "..\bin\Release\net10.0-windows\*.*"
+  File "..\bin\Release\net10.0-windows\win-x64\publish\qbPortWeaver.exe"
   File "..\README.md"
   
   CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"

--- a/qbPortWeaver.csproj
+++ b/qbPortWeaver.csproj
@@ -13,9 +13,9 @@
     <Product>qbPortWeaver</Product>
     <Authors>@martsg666</Authors>
     <Copyright>© 2026 @martsg666</Copyright>
-    <Version>2.1.0</Version>
-    <FileVersion>2.1.0.0</FileVersion>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <Version>2.2.0</Version>
+    <FileVersion>2.2.0.0</FileVersion>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
     <SignAssembly>False</SignAssembly>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon></PackageIcon>

--- a/scripts/Build-Local.ps1
+++ b/scripts/Build-Local.ps1
@@ -1,0 +1,124 @@
+<#
+.SYNOPSIS
+    Builds a local qbPortWeaver installer for testing purposes.
+
+.DESCRIPTION
+    Mirrors the CI build-release workflow locally:
+      1. Publishes the .NET app as a self-contained single-file win-x64 executable
+      2. Compiles the NSIS installer using the published output
+
+    Use this script before running makensis locally — a regular Visual Studio
+    Release build does NOT produce the self-contained single-file output that
+    the NSIS script expects under bin\Release\net10.0-windows\win-x64\publish\.
+
+.PARAMETER Version
+    The version string to stamp into the build (e.g. '2.2.0').
+    Defaults to the version defined in AppConstants.cs.
+
+.EXAMPLE
+    # Build using the default version from AppConstants.cs
+    .\scripts\Build-Local.ps1
+
+.EXAMPLE
+    # Build with an explicit version override
+    .\scripts\Build-Local.ps1 -Version 2.2.0
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Version = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Write-Step([string]$msg) { Write-Host "`n==> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)   { Write-Host "    $msg"   -ForegroundColor Green }
+
+# ---------------------------------------------------------------------------
+# Step 1: Resolve version — read from AppConstants.cs if not provided
+# ---------------------------------------------------------------------------
+Write-Step 'Resolving version...'
+
+if (-not $Version) {
+    $constantsPath = Join-Path $repoRoot 'AppConstants.cs'
+    $match = Select-String -Path $constantsPath -Pattern 'APP_VERSION\s*=\s*"([^"]+)"'
+    if (-not $match) {
+        Write-Error "Could not find APP_VERSION in AppConstants.cs. Pass -Version explicitly."
+        exit 1
+    }
+    $Version = $match.Matches[0].Groups[1].Value
+}
+
+Write-Ok "Version : $Version"
+
+# ---------------------------------------------------------------------------
+# Step 2: Publish as self-contained single-file win-x64
+#         This matches the CI build-release.yml publish step exactly.
+#         Output lands in: bin\Release\net10.0-windows\win-x64\publish\
+# ---------------------------------------------------------------------------
+Write-Step 'Publishing self-contained single-file executable...'
+
+Push-Location $repoRoot
+try {
+    dotnet publish qbPortWeaver.csproj `
+        --configuration Release `
+        --runtime win-x64 `
+        --self-contained true `
+        -p:PublishSingleFile=true `
+        -p:Version=$Version `
+        -p:FileVersion="$Version.0" `
+        -p:AssemblyVersion="$Version.0"
+
+    if ($LASTEXITCODE -ne 0) { Write-Error 'dotnet publish failed.'; exit 1 }
+} finally {
+    Pop-Location
+}
+
+$publishedExe = Join-Path $repoRoot "bin\Release\net10.0-windows\win-x64\publish\qbPortWeaver.exe"
+if (-not (Test-Path $publishedExe)) {
+    Write-Error "Expected publish output not found: $publishedExe"
+    exit 1
+}
+
+Write-Ok "Published : $publishedExe"
+
+# ---------------------------------------------------------------------------
+# Step 3: Compile the NSIS installer
+#         Must run from inside installer\ so relative paths in the .nsi
+#         script (..\ for bin output, icons, etc.) resolve correctly.
+#         Output: installer\qbPortWeaver_{version}_Setup.exe
+# ---------------------------------------------------------------------------
+Write-Step 'Compiling NSIS installer...'
+
+# Resolve makensis — check PATH first, then fall back to the default install location
+$makensis = 'makensis'
+if (-not (Get-Command makensis -ErrorAction SilentlyContinue)) {
+    $fallback = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
+    if (Test-Path $fallback) {
+        $makensis = $fallback
+        Write-Ok "Found makensis at: $makensis"
+    } else {
+        Write-Error "makensis not found. Install NSIS from https://nsis.sourceforge.io/"
+        exit 1
+    }
+}
+
+Push-Location (Join-Path $repoRoot 'installer')
+try {
+    & $makensis /DPRODUCT_VERSION=$Version qbPortWeaverSetup.nsi
+    if ($LASTEXITCODE -ne 0) { Write-Error 'makensis failed.'; exit 1 }
+} finally {
+    Pop-Location
+}
+
+$setupExe = Join-Path $repoRoot "installer\qbPortWeaver_${Version}_Setup.exe"
+if (-not (Test-Path $setupExe)) {
+    Write-Error "Expected installer not found: $setupExe"
+    exit 1
+}
+
+Write-Ok "Installer : $setupExe"
+Write-Host "`nDone." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Added `v` prefix to `releaseNotes` URL template in `choco/qbPortWeaver.nuspec` so the generated URL correctly points to the versioned GitHub release tag.

## Test plan
- [ ] Verify Chocolatey publish workflow generates correct `releaseNotes` URL after version substitution