### PR TITLE
Get version dynamically

### DIFF
--- a/AppConstants.cs
+++ b/AppConstants.cs
@@ -6,7 +6,8 @@ namespace qbPortWeaver
     {
         // Application metadata
         public const string APP_NAME = "qbPortWeaver";
-        public const string APP_VERSION = "2.2.0";
+        public static readonly string APP_VERSION =
+            System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
 
         // Timing
         public const int DEFAULT_UPDATE_INTERVAL_SECONDS = 180;


### PR DESCRIPTION
should fix #41 

Note that any local builds will be alerted for auto-updates based on the version defined inside the .csproj file, but this is (always) a red herring. All of our deployed builds are done server side via pipeline to maintain build provenance 