### PR TITLE
Soften recovery-trigger log wording to match time gate

### DIFF
--- a/qbPortWeaver/PortSyncService.cs
+++ b/qbPortWeaver/PortSyncService.cs
@@ -876,7 +876,7 @@ public sealed class PortSyncService
     {
         string cycles = count == 1 ? "failed cycle" : "failed cycles";
         string recoverySuffix = cfg.VpnAutoRecoveryEnabled
-            ? $", recovery triggers after {cfg.VpnAutoRecoveryTriggerCycles} consecutive failed cycles"
+            ? $", recovery may trigger after {cfg.VpnAutoRecoveryTriggerCycles} consecutive failed cycles"
             : string.Empty;
         return $"{prefix} ({count} consecutive {cycles}{recoverySuffix})";
     }


### PR DESCRIPTION
Recovery now also gates on the sustained-failure time floor, so the cycle-count line no longer always triggers at N cycles. Reworded to "may trigger".