### PR TITLE
Move recovery settings to a dedicated tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,6 @@ On first run, all settings are initialized with sensible defaults.
 | Update interval | How often to check and sync the port (seconds) | `180` |
 | Sync on network change | Also run a sync immediately when a network or VPN connection change is detected, instead of waiting for the next interval (rapid changes are coalesced; pausing still suppresses it) | `True` |
 | Wait for VPN on startup | For a short grace period after the app starts, wait quietly while the VPN is still connecting instead of reporting it as disconnected, applying the default-port fallback, or triggering auto-recovery. Syncs as soon as the VPN comes up | `True` |
-| Verify port after sync | After each sync, check that the listening port is reachable from the Internet (after a port change and every 5th cycle) | `True` |
-| Trigger auto-recovery when no port assigned or disconnected | Trigger auto-recovery (a VPN service restart, or adapter cycle for generic NAT-PMP gateways) after N consecutive cycles where the VPN is disconnected or assigns no forwarded port. Client-side failures do not count | `True` |
-| Trigger after (consecutive failed cycles) | Number of consecutive cycles without an assigned port before auto-recovery is triggered. Recovery is also held until the failures have persisted for the time these cycles would normally span, so a brief network blip that races through several early re-syncs does not trigger it | `3` |
-| Trigger auto-recovery when port stays closed | Independent trigger: runs auto-recovery when port verification confirms the port closed for the configured number of checks. Fires at most once until the port tests open again. Requires Verify port after sync | `True` |
-| Trigger after (confirmed closed checks) | Number of confirmed closed checks before auto-recovery is triggered | `3` |
 | Notify on port update | Show a tray balloon tip when the client's listening port is successfully updated | `True` |
 | Show update form on startup | When checked, opens the update form at startup if a newer version is found. When unchecked, only a tray notification is shown (the 12-hour periodic check is always non-intrusive) | `True` |
 
@@ -231,6 +226,18 @@ so the change is live within a few seconds and a restart would only discard sett
 | Force start if not running | Automatically launch Nicotine+ if it is not running | `True` |
 | Warn on interface mismatch | Warn if Nicotine+'s network interface doesn't match the VPN | `True` |
 | Default port (0 = disabled) | Fallback port to apply when VPN is not connected | `0` |
+
+#### Recovery
+
+Auto-recovery restarts your VPN service (or cycles the adapter for a generic NAT-PMP gateway) when the VPN stops providing a working forwarded port. The **Test** button runs the recovery action on demand.
+
+| Setting | Description | Default |
+|---|---|---|
+| Verify port after sync | After each sync, check that the listening port is reachable from the Internet (after a port change and every 5th cycle) | `True` |
+| Trigger auto-recovery when port stays closed | Independent trigger: runs auto-recovery when port verification confirms the port closed for the configured number of checks. Fires at most once until the port tests open again. Requires Verify port after sync | `True` |
+| Trigger after (confirmed closed checks) | Number of confirmed closed checks before auto-recovery is triggered | `3` |
+| Trigger auto-recovery when no port assigned or disconnected | Trigger auto-recovery (a VPN service restart, or adapter cycle for generic NAT-PMP gateways) after N consecutive cycles where the VPN is disconnected or assigns no forwarded port. Client-side failures do not count | `True` |
+| Trigger after (consecutive failed cycles) | Number of consecutive cycles without an assigned port before auto-recovery is triggered. Recovery is also held until the failures have persisted for the time these cycles would normally span, so a brief network blip that races through several early re-syncs does not trigger it | `3` |
 
 #### Extra
 

--- a/qbPortWeaver/SettingsForm.Designer.cs
+++ b/qbPortWeaver/SettingsForm.Designer.cs
@@ -23,7 +23,9 @@ partial class SettingsForm
         tabGeneral                = new TabPage();
         tabClient                 = new TabPage();
         tabExtra                  = new TabPage();
+        tabRecovery               = new TabPage();
         grpGeneral                = new GroupBox();
+        grpRecovery               = new GroupBox();
         lblVpnProvider            = new Label();
         cboVpnProvider            = new ComboBox();
         lblClient       = new Label();
@@ -132,7 +134,9 @@ partial class SettingsForm
         tabGeneral.SuspendLayout();
         tabClient.SuspendLayout();
         tabExtra.SuspendLayout();
+        tabRecovery.SuspendLayout();
         grpGeneral.SuspendLayout();
+        grpRecovery.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)nudUpdateInterval).BeginInit();
         ((System.ComponentModel.ISupportInitialize)nudRecoveryCycles).BeginInit();
         ((System.ComponentModel.ISupportInitialize)nudPortClosedChecks).BeginInit();
@@ -162,17 +166,17 @@ partial class SettingsForm
         grpGeneral.Controls.Add(chkNotifyOnPortUpdate);
         grpGeneral.Controls.Add(chkShowUpdateForm);
         grpGeneral.Controls.Add(chkWaitForVpnOnStartup);
-        grpGeneral.Controls.Add(lblAutoRecoveryHeader);
-        grpGeneral.Controls.Add(btnTestRecovery);
-        grpGeneral.Controls.Add(chkVerifyPort);
-        grpGeneral.Controls.Add(chkPortClosedRecovery);
-        grpGeneral.Controls.Add(lblPortClosedChecks);
-        grpGeneral.Controls.Add(nudPortClosedChecks);
-        grpGeneral.Controls.Add(lblPortClosedChecksUnit);
-        grpGeneral.Controls.Add(chkAutoRecovery);
-        grpGeneral.Controls.Add(lblRecoveryCycles);
-        grpGeneral.Controls.Add(nudRecoveryCycles);
-        grpGeneral.Controls.Add(lblRecoveryCyclesUnit);
+        grpRecovery.Controls.Add(lblAutoRecoveryHeader);
+        grpRecovery.Controls.Add(btnTestRecovery);
+        grpRecovery.Controls.Add(chkVerifyPort);
+        grpRecovery.Controls.Add(chkPortClosedRecovery);
+        grpRecovery.Controls.Add(lblPortClosedChecks);
+        grpRecovery.Controls.Add(nudPortClosedChecks);
+        grpRecovery.Controls.Add(lblPortClosedChecksUnit);
+        grpRecovery.Controls.Add(chkAutoRecovery);
+        grpRecovery.Controls.Add(lblRecoveryCycles);
+        grpRecovery.Controls.Add(nudRecoveryCycles);
+        grpRecovery.Controls.Add(lblRecoveryCyclesUnit);
         // All five group boxes share one size that fills the tab page with an even margin,
         // so every tab shows an identical frame regardless of how much content it holds.
         grpGeneral.Location = new Point(6, 6);
@@ -181,6 +185,12 @@ partial class SettingsForm
         grpGeneral.TabIndex = 0;
         grpGeneral.TabStop  = false;
         grpGeneral.Text     = "General";
+        grpRecovery.Location = new Point(6, 6);
+        grpRecovery.Name     = "grpRecovery";
+        grpRecovery.Size     = new Size(488, 380);
+        grpRecovery.TabIndex = 0;
+        grpRecovery.TabStop  = false;
+        grpRecovery.Text     = "Recovery";
         lblClient.Location  = new Point(12, 24);
         lblClient.Name      = "lblClient";
         lblClient.Size      = new Size(130, 23);
@@ -284,25 +294,25 @@ partial class SettingsForm
         // "Trigger after" labels use AutoSize so the NUD sits immediately after the text.
         lblAutoRecoveryHeader.AutoSize = true;
         lblAutoRecoveryHeader.Font     = new Font("Segoe UI", 9F, FontStyle.Bold);
-        lblAutoRecoveryHeader.Location = new Point(12, 198);
+        lblAutoRecoveryHeader.Location = new Point(12, 24);
         lblAutoRecoveryHeader.Name     = "lblAutoRecoveryHeader";
         lblAutoRecoveryHeader.TabIndex = 15;
         lblAutoRecoveryHeader.Text     = "Auto-recovery";
         // Shares the header row, matching the client groups' Test button placement (x=398).
-        btnTestRecovery.Location = new Point(398, 198);
+        btnTestRecovery.Location = new Point(398, 24);
         btnTestRecovery.Name     = "btnTestRecovery";
         btnTestRecovery.Size     = new Size(70, 23);
         btnTestRecovery.TabIndex = 16;
         btnTestRecovery.Text     = "Test";
         btnTestRecovery.Click   += btnTestRecovery_Click;
         chkVerifyPort.AutoSize        = true;
-        chkVerifyPort.Location        = new Point(15, 227);
+        chkVerifyPort.Location        = new Point(15, 53);
         chkVerifyPort.Name            = "chkVerifyPort";
         chkVerifyPort.TabIndex        = 17;
         chkVerifyPort.Text            = "Check that the forwarded port is open after each sync";
         chkVerifyPort.CheckedChanged += chkVerifyPort_CheckedChanged;
         chkPortClosedRecovery.AutoSize       = true;
-        chkPortClosedRecovery.Location       = new Point(15, 256);
+        chkPortClosedRecovery.Location       = new Point(15, 82);
         chkPortClosedRecovery.Name           = "chkPortClosedRecovery";
         chkPortClosedRecovery.TabIndex       = 18;
         chkPortClosedRecovery.Text           = "Trigger auto-recovery when port stays closed";
@@ -310,44 +320,44 @@ partial class SettingsForm
         // "Trigger after" sub-rows align with the parent checkbox's text at x=28 (checkbox left 12 +
         // ~16px glyph/margin). NUD and unit-label X are finalized in OnLoad via PreferredSize.Width.
         lblPortClosedChecks.AutoSize  = true;
-        lblPortClosedChecks.Location  = new Point(28, 285);
+        lblPortClosedChecks.Location  = new Point(28, 111);
         lblPortClosedChecks.Name      = "lblPortClosedChecks";
         lblPortClosedChecks.TabIndex  = 19;
         lblPortClosedChecks.Text      = "Trigger after";
         lblPortClosedChecks.TextAlign = ContentAlignment.MiddleLeft;
-        nudPortClosedChecks.Location = new Point(112, 285);
+        nudPortClosedChecks.Location = new Point(112, 111);
         nudPortClosedChecks.Maximum  = new decimal(new int[] { 10, 0, 0, 0 });
         nudPortClosedChecks.Minimum  = new decimal(new int[] { 1, 0, 0, 0 });
         nudPortClosedChecks.Name     = "nudPortClosedChecks";
         nudPortClosedChecks.Size     = new Size(50, 23);
         nudPortClosedChecks.TabIndex = 20;
         nudPortClosedChecks.Value    = new decimal(new int[] { 3, 0, 0, 0 });
-        lblPortClosedChecksUnit.Location  = new Point(168, 285);
+        lblPortClosedChecksUnit.Location  = new Point(168, 111);
         lblPortClosedChecksUnit.Name      = "lblPortClosedChecksUnit";
         lblPortClosedChecksUnit.Size      = new Size(270, 23);
         lblPortClosedChecksUnit.TabIndex  = 21;
         lblPortClosedChecksUnit.Text      = "confirmed closed checks";
         lblPortClosedChecksUnit.TextAlign = ContentAlignment.MiddleLeft;
         chkAutoRecovery.AutoSize       = true;
-        chkAutoRecovery.Location       = new Point(15, 314);
+        chkAutoRecovery.Location       = new Point(15, 140);
         chkAutoRecovery.Name           = "chkAutoRecovery";
         chkAutoRecovery.TabIndex       = 22;
         chkAutoRecovery.Text           = "Trigger auto-recovery when no port assigned or disconnected";
         chkAutoRecovery.CheckedChanged += chkAutoRecovery_CheckedChanged;
         lblRecoveryCycles.AutoSize  = true;
-        lblRecoveryCycles.Location  = new Point(28, 343);
+        lblRecoveryCycles.Location  = new Point(28, 169);
         lblRecoveryCycles.Name      = "lblRecoveryCycles";
         lblRecoveryCycles.TabIndex  = 23;
         lblRecoveryCycles.Text      = "Trigger after";
         lblRecoveryCycles.TextAlign = ContentAlignment.MiddleLeft;
-        nudRecoveryCycles.Location = new Point(112, 343);
+        nudRecoveryCycles.Location = new Point(112, 169);
         nudRecoveryCycles.Maximum  = new decimal(new int[] { 10, 0, 0, 0 });
         nudRecoveryCycles.Minimum  = new decimal(new int[] { 1, 0, 0, 0 });
         nudRecoveryCycles.Name     = "nudRecoveryCycles";
         nudRecoveryCycles.Size     = new Size(50, 23);
         nudRecoveryCycles.TabIndex = 24;
         nudRecoveryCycles.Value    = new decimal(new int[] { 3, 0, 0, 0 });
-        lblRecoveryCyclesUnit.Location  = new Point(168, 343);
+        lblRecoveryCyclesUnit.Location  = new Point(168, 169);
         lblRecoveryCyclesUnit.Name      = "lblRecoveryCyclesUnit";
         lblRecoveryCyclesUnit.Size      = new Size(270, 23);
         lblRecoveryCyclesUnit.TabIndex  = 25;
@@ -849,6 +859,7 @@ partial class SettingsForm
         // other on the Client tab; their existing visibility toggling is unchanged.
         tabSettings.Controls.Add(tabGeneral);
         tabSettings.Controls.Add(tabClient);
+        tabSettings.Controls.Add(tabRecovery);
         tabSettings.Controls.Add(tabExtra);
         tabSettings.Padding       = new Point(16, 5); // larger native tabs - auto-sized to text, centered and theme-correct in dark mode
         tabSettings.Location      = new Point(8, 8);
@@ -868,6 +879,9 @@ partial class SettingsForm
         tabClient.Controls.Add(grpTransmission);
         tabClient.Name = "tabClient";
         tabClient.Text = "Client";
+        tabRecovery.Controls.Add(grpRecovery);
+        tabRecovery.Name = "tabRecovery";
+        tabRecovery.Text = "Recovery";
         tabExtra.Controls.Add(grpExtra);
         tabExtra.Name = "tabExtra";
         tabExtra.Text = "Extra";
@@ -904,6 +918,8 @@ partial class SettingsForm
         Text            = "qbPortWeaver | Settings"; // overridden in constructor
         grpGeneral.ResumeLayout(false);
         grpGeneral.PerformLayout();
+        grpRecovery.ResumeLayout(false);
+        grpRecovery.PerformLayout();
         ((System.ComponentModel.ISupportInitialize)nudUpdateInterval).EndInit();
         ((System.ComponentModel.ISupportInitialize)nudRecoveryCycles).EndInit();
         ((System.ComponentModel.ISupportInitialize)nudPortClosedChecks).EndInit();
@@ -923,6 +939,7 @@ partial class SettingsForm
         grpExtra.PerformLayout();
         tabGeneral.ResumeLayout(false);
         tabClient.ResumeLayout(false);
+        tabRecovery.ResumeLayout(false);
         tabExtra.ResumeLayout(false);
         tabSettings.ResumeLayout(false);
         ResumeLayout(false);
@@ -932,8 +949,10 @@ partial class SettingsForm
     private TabPage       tabGeneral;
     private TabPage       tabClient;
     private TabPage       tabExtra;
+    private TabPage       tabRecovery;
 
     private GroupBox      grpGeneral;
+    private GroupBox      grpRecovery;
     private Label         lblClient;
     private ComboBox      cboClient;
     private Button        btnDetectClient;

--- a/qbPortWeaver/WhatsNewForm.cs
+++ b/qbPortWeaver/WhatsNewForm.cs
@@ -16,6 +16,9 @@ public partial class WhatsNewForm : Form
         "Settings has an Install plugin button that sets up a small bridge plugin for you - and " +
         "enables it too, if Nicotine+ is closed at the time. The port then changes while " +
         "Nicotine+ keeps running: no restart, no interrupted transfers.\n\n" +
+        "Recovery settings on their own tab\n" +
+        "The port-verification and auto-recovery options have moved to a dedicated Recovery tab in " +
+        "Settings, so the General tab is less crowded and the recovery options are easier to find.\n\n" +
         "Previously released\n\n" +
         "New in 2.6.3\n\n" +
         "Pop-up messages match your theme\n" +


### PR DESCRIPTION
Moves the port-verification and auto-recovery options out of the crowded General tab into a new Auto-Recovery tab (order: General, Client, Auto-Recovery, Extra). README settings section and What's New updated to match.